### PR TITLE
Fix for failing on private inventories

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@ SteamTradeOffers.prototype.loadPartnerInventory = function(partner, appid, conte
 };
 
 function mergeWithDescriptions(items, descriptions, contextid) {
+  if(!items) {
+    return [];
+  }
   return Object.keys(items).map(function(id) {
     var item = items[id];
     var description = descriptions[item.classid + '_' + (item.instanceid || '0')];


### PR DESCRIPTION
Trying to execute loadPartnerInventory() on someone with private inventory crashes everything.  
See stack trace of the crash below.  
This PR fixes the problem.  

``` js
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at mergeWithDescriptions (node_modules/steam-tradeoffers/index.js:136:17)
    at SteamTradeOffers.<anonymous> (node_modules/steam-tradeoffers/index.js:94:36)
    at Request.self.callback (node_modules/steam-tradeoffers/node_modules/request/request.js:129:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (node_modules/steam-tradeoffers/node_modules/request/request.js:873:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (node_modules/steam-tradeoffers/node_modules/request/request.js:824:12)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:919:16
```
