### PR TITLE
fix inventory not loading when the inventory is private + better logging in acceptOffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,14 +127,13 @@ SteamTradeOffers.prototype._loadInventory = function(inventory, uri, options, co
 
   this._request.get(options, function(error, response, body) {
     var self = this;
-    if (error || response.statusCode != 200 || JSON.stringify(body) == '{}') {
-      this.emit('debug', 'loading ' + uri +': ' + (error || (response.statusCode != 200 ? response.statusCode : '{}')));
-      setTimeout(function() { self._loadInventory(inventory, uri, options, contextid, start, callback); }, 1000);
-    } else if (typeof body != 'object') {
-      // no session
+    if (body && ((typeof body === 'object' && body.success === false) || typeof body != 'object' )) {
       if(typeof callback == 'function'){
         callback(new Error('No session'));
       }
+    } else if (error || response.statusCode != 200 || JSON.stringify(body) == '{}') {
+      this.emit('debug', 'loading ' + uri +': ' + (error || (response.statusCode != 200 ? response.statusCode : '{}')));
+      setTimeout(function() { self._loadInventory(inventory, uri, options, contextid, start, callback); }, 1000);
     } else if (body.success == false) {
       // inventory not found
       if(typeof callback == 'function'){


### PR DESCRIPTION
Inventory loading requires the trade offer id when an offer is received if the inventory is private. Will default to 'new' if a trade offer id is not specified, so it won't break existing code.

Added better logging to acceptOffer (see #30)
