### PR TITLE
Protect from exception in case of empty getOffer response

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,9 @@ SteamTradeOffers.prototype.getOffer = function(options, callback) {
           callback(error);
         }
       } else {
-        res.response.offer.steamid_other = toSteamId(res.response.offer.accountid_other);
+        if (res && res.response && res.response.offer && res.response.offer.steamid_other) {
+          res.response.offer.steamid_other = toSteamId(res.response.offer.accountid_other);
+        }
         if(typeof callback == 'function'){
           callback(null, res);
         }

--- a/index.js
+++ b/index.js
@@ -210,13 +210,13 @@ SteamTradeOffers.prototype.getOffers = function(options, callback) {
           callback(error);
         }
       } else {
-        if (res.response.trade_offers_received !== undefined) {
+        if (res && res.response && res.response.trade_offers_received !== undefined) {
           res.response.trade_offers_received = res.response.trade_offers_received.map(function(offer) {
             offer.steamid_other = toSteamId(offer.accountid_other);
             return offer;
           });
         }
-        if (res.response.trade_offers_sent !== undefined) {
+        if (res && res.response && res.response.trade_offers_sent !== undefined) {
           res.response.trade_offers_sent = res.response.trade_offers_sent.map(function(offer) {
             offer.steamid_other = toSteamId(offer.accountid_other);
             return offer;

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ SteamTradeOffers.prototype.getOffer = function(options, callback) {
           callback(error);
         }
       } else {
-        if (res && res.response && res.response.offer && res.response.offer.steamid_other) {
+        if (res && res.response && res.response.offer && res.response.offer.accountid_other) {
           res.response.offer.steamid_other = toSteamId(res.response.offer.accountid_other);
         }
         if(typeof callback == 'function'){


### PR DESCRIPTION
The library creates an uncaught exception when Steam returns an empty response crashing the application that relies on this package.

This patch will be more wary of an empty response.