### PR TITLE
Add getOfferToken() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Options:
 
 The second argument to `callback` will be an object with response from Steam, but don't expect anything meaningful in it.
 
+## getOfferToken(callback)
+
+The second argument to `callback` will be the offer token of the bot, extracted from its trade offer URL.
+
+
 # FAQ
 
 Please read this list of common issues before creating an issue.

--- a/index.js
+++ b/index.js
@@ -80,7 +80,10 @@ SteamTradeOffers.prototype.getOfferToken = function(callback) {
   }, function(error, response, body) {
     if (error || response.statusCode != 200) {
       self.emit('debug', 'retrieving offer token: ' + (error || response.statusCode));
-      callback(error, null);
+
+      if (typeof callback == 'function') {
+        callback(new Error(error || response.statusCode), null);
+      }
     } else {
       var $ = cheerio.load(body);
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ SteamTradeOffers.prototype.getOfferToken = function(callback) {
   }, function(error, response, body) {
     if (error || response.statusCode != 200) {
       self.emit('debug', 'retrieving offer token: ' + (error || response.statusCode));
-      getOfferToken(self, callback);
+      callback(error, null);
     } else {
       var $ = cheerio.load(body);
 
@@ -88,7 +88,7 @@ SteamTradeOffers.prototype.getOfferToken = function(callback) {
       var offerToken = url.parse(offerUrl, true).query.token;
 
       if (typeof callback == 'function') {
-        callback(offerToken);
+        callback(null, offerToken);
       }
 
     }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = SteamTradeOffers;
 var request = require('request');
 var cheerio = require('cheerio');
 var Long = require('long');
+var url = require('url');
 var querystring = require('querystring');
 
 require('util').inherits(SteamTradeOffers, require('events').EventEmitter);
@@ -68,6 +69,30 @@ function getAPIKey(self, callback) {
       }
     }
   }.bind(self));
+}
+
+
+SteamTradeOffers.prototype.getOfferToken = function(callback) {
+  var self = this;
+
+  self._request.get({
+    uri: 'http://steamcommunity.com/id/me/tradeoffers/privacy'
+  }, function(error, response, body) {
+    if (error || response.statusCode != 200) {
+      self.emit('debug', 'retrieving offer token: ' + (error || response.statusCode));
+      getOfferToken(self, callback);
+    } else {
+      var $ = cheerio.load(body);
+
+      var offerUrl = $('input#trade_offer_access_url').val();
+      var offerToken = url.parse(offerUrl, true).query.token;
+
+      if (typeof callback == 'function') {
+        callback(offerToken);
+      }
+
+    }
+  });
 }
 
 function setCookie(self, cookie) {


### PR DESCRIPTION
Implementing the suggestion from #56

I added a SteamTradeOffers.prototype.getOfferToken(callback) method to get the offer token from the bot's trade URL. I'm not really used to GitHub, or git in general, so tell me if something's wrong with that PR and I'll be happy to fix it :)

```javascript
offers.getOfferToken(function(err, token) {
  if (err) {
    throw err;
    return;
  }
  console.log(token);
});
```