### PR TITLE
SteamTradeOffers.prototype.getOfferToken fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ SteamTradeOffers.prototype.getOfferToken = function(callback) {
     }
 
     var $ = cheerio.load(body);
-    var offerUrl = $('input#trade_offer_access_url').val();
+    var offerUrl = $('input#trade_offer_access_url').attr("value");
     var offerToken = url.parse(offerUrl, true).query.token;
 
     callback(null, offerToken);


### PR DESCRIPTION
cheerio dont have .val() method, so for getting offerurl we need to use .attr("value") which supported by cheerio