### PR TITLE
Fix syntax highlighting in one of the code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Options:
 
 The second argument to `callback` will be an object like:
 
-```json
+```js
 { my: 0, their: 0 }
 ```
 


### PR DESCRIPTION
This fixes the language identifier in one of the fenced code blocks.