### PR TITLE
Add local address to load inventory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -432,6 +432,10 @@ function loadInventory(options, callback) {
   if (options.headers) {
     requestParams.headers = options.headers;
   }
+  
+  if(options.localAddress) {
+    requestParams.localAddress = options.localAddress;
+  }
 
   this._requestCommunity.get(requestParams, function(error, response, body) {
     if (error) {


### PR DESCRIPTION
This allows you to call this function from different ip addresses in order to decrease rate limiting.
