### PR TITLE
Add handle for loadInventory case if inventory is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,8 +443,11 @@ function loadInventory(options, callback) {
     if (response && response.statusCode !== 200) {
       return callback(new Error(response.statusCode));
     }
-    if (!body || !body.rgInventory || !body.rgDescriptions || !body.rgCurrency) {
+
+    if (!body) {
       return callback(new Error('Invalid Response'));
+    } else if (!body.rgInventory || !body.rgDescriptions || !body.rgCurrency) { // Inventory is empty
+      return callback();
     }
 
     options.raw = mergeRawInventory(options.raw, body);
@@ -532,7 +535,7 @@ function getHoldDuration (url, callback) {
     };
 
     // prepare to execute the script in new context
-    var code = scriptToExec + 
+    var code = scriptToExec +
       'data.my = g_daysMyEscrow;' +
       'data.their = g_daysTheirEscrow;';
 


### PR DESCRIPTION
If a steam account has empty inventory, the library still raise error.
It would be great if you could add some handler to check empty inventory and response other state than error.

Thank you
Phuong
