### PR TITLE
Check oItem's length and number of acquired items

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,6 +329,13 @@ SteamTradeOffers.prototype.getItems = function(options, callback) {
       return callback(new Error('Invalid Response'));
     }
 
+    var $ = cheerio.load(body);
+    var header = $('.received_items_header h1')[1];
+    var itemsCount = parseInt($(header).text().trim().split(' '));
+    if (isNaN(itemsCount)) {
+      return callback(null, []);
+    }
+
     var script = body.match(/(var oItem;[\s\S]*)<\/script>/);
     if (!script) {
       return callback(new Error('No session'));
@@ -351,6 +358,11 @@ SteamTradeOffers.prototype.getItems = function(options, callback) {
       script[1];
 
     vm.runInNewContext(code, sandbox);
+
+    // Sometimes oItem is empty even if there are acquired items
+    if (sandbox.items.length !== itemsCount) {
+      return callback(new Error('Invalid Response'));
+    }
 
     callback(null, sandbox.items);
   });


### PR DESCRIPTION
Sometimes `getItems` return empty array even if there are acquired items.
The reason is `/trade/:tradeId/receipt/' sometimes returns oItem as null.

We can check if `oItem` is supposed to be null or not by checking a header on html which will be `N new item acquired` or `No new items acquired`.
I add check into the function, and it will throw `Invalid Response` if response from steam is invalid.
Please review my pull request.

Thank you
