### PR TITLE
Fix acceptOffer() not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Options:
  The second argument to `callback` will be an object that Steam Web API returns. The only thing to note is that the wrapper adds a property `steamid_other` with the SteamID of the trade partner to each `CEcon_TradeOffer` object in received trades.
 
 ## declineOffer(options[, callback])
-## acceptOffer(offer[, callback])
+## acceptOffer(options[, callback])
 ## cancelOffer(options[, callback])
 
 `declineOffer` or `acceptOffer` that was sent to you. `cancelOffer` that you sent.
@@ -142,9 +142,7 @@ Options:
 Options:
 
 * `tradeOfferId` is a trade offer Id
-
-Offer:
-`offer` is the specific trade offer object from `getOffers()`
+* `partnerSteamId` is the steamid64 of the other person
 
 The second argument to `callback` will be an object with response from Steam, but don't expect anything meaningful in it.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Options:
  The second argument to `callback` will be an object that Steam Web API returns. The only thing to note is that the wrapper adds a property `steamid_other` with the SteamID of the trade partner to each `CEcon_TradeOffer` object in received trades.
 
 ## declineOffer(options[, callback])
-## acceptOffer(options[, callback])
+## acceptOffer(offer[, callback])
 ## cancelOffer(options[, callback])
 
 `declineOffer` or `acceptOffer` that was sent to you. `cancelOffer` that you sent.
@@ -142,6 +142,9 @@ Options:
 Options:
 
 * `tradeOfferId` is a trade offer Id
+
+Offer:
+`offer` is the specific trade offer object from `getOffers()`
 
 The second argument to `callback` will be an object with response from Steam, but don't expect anything meaningful in it.
 

--- a/examples/storehouse.js
+++ b/examples/storehouse.js
@@ -82,7 +82,7 @@ function handleOffers() {
       body.response.trade_offers_received.forEach(function(offer) {
         if (offer.trade_offer_state === 2) {
           if (offer.steamid_other === admin) {
-            offers.acceptOffer(offer);
+            offers.acceptOffer({tradeOfferId: offer.tradeofferid, partnerSteamId: offer.steamid_other});
           } else {
             offers.declineOffer({tradeOfferId: offer.tradeofferid});
           }

--- a/examples/storehouse.js
+++ b/examples/storehouse.js
@@ -82,7 +82,7 @@ function handleOffers() {
       body.response.trade_offers_received.forEach(function(offer) {
         if (offer.trade_offer_state === 2) {
           if (offer.steamid_other === admin) {
-            offers.acceptOffer({tradeOfferId: offer.tradeofferid});
+            offers.acceptOffer(offer);
           } else {
             offers.declineOffer({tradeOfferId: offer.tradeofferid});
           }

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ SteamTradeOffers.prototype.cancelOffer = function(options, callback) {
   });
 };
 
-SteamTradeOffers.prototype.acceptOffer = function(options, callback) {
+SteamTradeOffers.prototype.acceptOffer = function(offer, callback) {
   var cb = function () {
     if (typeof callback === 'function') {
       callback.apply(null, arguments);
@@ -222,15 +222,16 @@ SteamTradeOffers.prototype.acceptOffer = function(options, callback) {
   };
 
   this._requestCommunity.post({
-    uri: communityURL + '/tradeoffer/' + options.tradeOfferId + '/accept',
+    uri: communityURL + '/tradeoffer/' + offer.tradeofferid + '/accept',
     headers: {
-      referer: communityURL + '/tradeoffer/' + options.tradeOfferId + '/'
+      referer: communityURL + '/tradeoffer/' + offer.tradeofferid + '/'
     },
     json: true,
     form: {
       sessionid: this.sessionID,
       serverid: 1,
-      tradeofferid: options.tradeOfferId
+      tradeofferid: offer.tradeofferid,
+      partner: offer.steamid_other
     }
   }, function(error, response, body) {
     if (error) {

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ SteamTradeOffers.prototype.cancelOffer = function(options, callback) {
   });
 };
 
-SteamTradeOffers.prototype.acceptOffer = function(offer, callback) {
+SteamTradeOffers.prototype.acceptOffer = function(options, callback) {
   var cb = function () {
     if (typeof callback === 'function') {
       callback.apply(null, arguments);
@@ -222,16 +222,16 @@ SteamTradeOffers.prototype.acceptOffer = function(offer, callback) {
   };
 
   this._requestCommunity.post({
-    uri: communityURL + '/tradeoffer/' + offer.tradeofferid + '/accept',
+    uri: communityURL + '/tradeoffer/' + options.tradeOfferId + '/accept',
     headers: {
-      referer: communityURL + '/tradeoffer/' + offer.tradeofferid + '/'
+      referer: communityURL + '/tradeoffer/' + options.tradeOfferId + '/'
     },
     json: true,
     form: {
       sessionid: this.sessionID,
       serverid: 1,
-      tradeofferid: offer.tradeofferid,
-      partner: offer.steamid_other
+      tradeofferid: options.tradeOfferId,
+      partner: options.partnerSteamId
     }
   }, function(error, response, body) {
     if (error) {


### PR DESCRIPTION
Valve changed how offers are accepted awhile back, and acceptOffer() as it stands no longer functions. You have to add the partner steam id to the form being passed. 

This PR fixes this, and updates the readme / example for the new change.