### PR TITLE
Add function to validate a trade offer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ The second argument to `callback` will be the trade offer URL.
 
 The second argument to `callback` will be the offer token of the bot, extracted from its trade offer URL.
 
+## validateOfferUrl(offerUrl, callback)
+
+The second argument to `callback` will be a boolean.
+
 ## getItems(options, callback)
 
 Options:

--- a/index.js
+++ b/index.js
@@ -71,6 +71,25 @@ SteamTradeOffers.prototype.getOfferUrl = function(callback) {
   }.bind(this));
 };
 
+SteamTradeOffers.prototype.validateOfferUrl = function(offerUrl, callback) {
+  this._requestCommunity.get({
+    uri: offerUrl
+  }, function(error, response, body) {
+    if (error || (response && response.statusCode !== 200)) {
+      return callback(error || new Error(response.statusCode));
+    }
+    if (!body) {
+      return callback(new Error('Invalid Response'));
+    }
+
+    if (body.indexOf("trade_partner_info_block") == -1) {
+      return callback(new Error('Invalid Response'));
+    }
+
+    callback(null, true);
+  }.bind(this));
+};
+
 SteamTradeOffers.prototype.getTradeHoldDuration = function(options, callback) {
   var url = communityURL + '/tradeoffer/' + options.tradeOfferId + '/';
 

--- a/index.js
+++ b/index.js
@@ -81,9 +81,8 @@ SteamTradeOffers.prototype.validateOfferUrl = function(offerUrl, callback) {
     if (!body) {
       return callback(new Error('Invalid Response'));
     }
-
-    if (body.indexOf("trade_partner_info_block") == -1) {
-      return callback(new Error('Invalid Response'));
+    if (body.indexOf('trade_partner_info_block') === -1) {
+      return callback(null, false);
     }
 
     callback(null, true);


### PR DESCRIPTION
The validateOfferUrl function request the url, and check the validity of it
Example:
offers.validateOfferUrl('https://steamcommunity.com/tradeoffer/new/?partner=50938317&token=qJVu_Ssk', function(err, isValid) {
  if(err || !isValid) {
    console.log('URL seems to be invalid');
  }
  console.log('URL seems to be valid');
});